### PR TITLE
fix updater logic

### DIFF
--- a/make/update.sh
+++ b/make/update.sh
@@ -10,6 +10,9 @@ next_jdk_version=$((current_jdk_version+1))
 next_jdk_tag_url="https://registry.hub.docker.com/v2/repositories/openjdk/openjdk/tags/${next_jdk_version}-jdk-alpine"
 if curl -s -H "Accept: application/json" ${next_jdk_tag_url} | grep "errinfo" >/dev/null ; then
     next_jdk_version=${current_jdk_version}
+    echo "found new JDK version: ${next_jdk_version}"
+else
+    echo "could not find new JDK version"
 fi
 echo "openjdk : ${current_jdk_version} -> ${next_jdk_version}"
 
@@ -18,16 +21,23 @@ current_plantuml_version=$(awk '/ARG PLANTUML_VERSION.*/ {
     match($0, /"(.+)"/);
     print substr($0, RSTART+1, RLENGTH-2);
 }' ./Dockerfile)
-next_plantuml_patch_version=$(echo "${current_plantuml_version}" | awk -F'.' '{
-    printf "%d.%d.%d",$1,$2,($3+1);
-}')
-next_plantuml_patch_url="http://downloads.sourceforge.net/project/plantuml/${next_plantuml_patch_version}/plantuml.${next_plantuml_patch_version}.jar"
-if ! curl --head -s --fail ${next_plantuml_patch_url} ; then
-    next_plantuml_patch_version=${current_plantuml_version}
+# TODO: updating major version
+major_version=$(echo "${current_plantuml_version}" | awk -F'.' '{print $1}')
+current_year=$(date +"%Y")
+next_patch_version=$(echo "${current_plantuml_version}" | awk -F'.' '{printf "%d", ($3+1)}')
+next_plantuml_version="${major_version}.${current_year}.${next_patch_version}"
+next_plantuml_version_url="http://downloads.sourceforge.net/project/plantuml/${next_plantuml_version}/plantuml.${next_plantuml_version}.jar"
+if curl --head -s --fail "${next_plantuml_version_url}" ; then
+    echo "found new plantuml version: ${next_plantuml_version}"
+else
+    echo "could not find new plantuml version"
+    next_plantuml_version=${current_plantuml_version}
 fi
-echo "plantuml : ${current_plantuml_version} -> ${next_plantuml_patch_version}"
+echo "plantuml : ${current_plantuml_version} -> ${next_plantuml_version}"
 
 sed -E "s/ARG JDK_VERSION.*/ARG JDK_VERSION=\"${next_jdk_version}\"/" ./Dockerfile > ./Dockerfile.new && mv ./Dockerfile.new ./Dockerfile
-sed -E "s/ARG PLANTUML_VERSION.*/ARG PLANTUML_VERSION=\"${next_plantuml_patch_version}\"/" ./Dockerfile > ./Dockerfile.new && mv ./Dockerfile.new ./Dockerfile
+sed -E "s/ARG PLANTUML_VERSION.*/ARG PLANTUML_VERSION=\"${next_plantuml_version}\"/" ./Dockerfile > ./Dockerfile.new && mv ./Dockerfile.new ./Dockerfile
+
+git --no-pager diff
 
 exit 0


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- plantuml version update logic didnt work as expected

## What
<!-- What features are added in this PR -->
- fix plantuml update logic 

## QA, Evidence
<!-- Things that support this PR is correct -->

### runtting make updater

```
$ make update                                              (git)-[fix-update-logic] 
found new JDK version: 15
openjdk : 15 -> 15
HTTP/1.1 302 Found
Server: nginx
Date: Sat, 25 Jul 2020 12:21:29 GMT
Content-Type: text/html; charset=UTF-8
Connection: keep-alive
Content-Disposition: attachment; filename="plantuml.1.2020.6.jar"
Set-Cookie: sf_mirror_attempt=plantuml:astuteinternet:1.2020.6/plantuml.1.2020.6.jar; Max-Age=120; Path=/; expires=Sat, 25-Jul-2020 12:23:29 GMT
Location: https://astuteinternet.dl.sourceforge.net/project/plantuml/1.2020.6/plantuml.1.2020.6.jar

found new plantuml version: 1.2020.6
plantuml : 1.2020.5 -> 1.2020.6

diff --git a/Dockerfile b/Dockerfile
index c9c1329..10a4ef7 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG JDK_VERSION="15"
 FROM openjdk:${JDK_VERSION}-jdk-alpine
 
-ARG PLANTUML_VERSION="1.2020.5"
+ARG PLANTUML_VERSION="1.2020.6"
 COPY ./plantuml /usr/local/bin/plantuml
```

now you get new version :)
